### PR TITLE
Don't spam log every frame, and support the new 1.0.5 flow mode

### DIFF
--- a/Source/PartExtensions.cs
+++ b/Source/PartExtensions.cs
@@ -64,8 +64,10 @@ namespace Tac
                     return TakeResource_AllVessel(part, resource, demand);
                 case ResourceFlowMode.STACK_PRIORITY_SEARCH:
                     return TakeResource_StackPriority(part, resource, demand);
+                case ResourceFlowMode.STAGE_STACK_FLOW_BALANCE:
+                    return part.RequestResource(resource.id, demand); // for now treat as SPF rather than SPS.
                 case ResourceFlowMode.STAGE_PRIORITY_FLOW:
-                    Debug.LogWarning("Tac.PartExtensions.TakeResource: ResourceFlowMode.STAGE_PRIORITY_FLOW is not supported yet.");
+                    //Debug.LogWarning("Tac.PartExtensions.TakeResource: ResourceFlowMode.STAGE_PRIORITY_FLOW is not supported yet.");
                     return part.RequestResource(resource.id, demand);
                 default:
                     Debug.LogWarning("Tac.PartExtensions.TakeResource: Unknown ResourceFlowMode = " + resource.resourceFlowMode.ToString());


### PR DESCRIPTION
@taraniselsu if you could, could you please release an updated TACLS with this? Right now everyone in RO is getting logspam every frame from this, and it's really slowing things down. Thanks!
