### PR TITLE
KSP 1.1 Fixes

### DIFF
--- a/Source/Icon.cs
+++ b/Source/Icon.cs
@@ -45,33 +45,7 @@ namespace Tac
         private GUIContent content;
         private GUIStyle iconStyle;
 
-        private bool visible;
-        public bool Visible
-        {
-            get
-            {
-                return visible;
-            }
-            set
-            {
-                if (value)
-                {
-                    if (!visible)
-                    {
-                        RenderingManager.AddToPostDrawQueue(3, DrawIcon);
-                    }
-                }
-                else
-                {
-                    if (visible)
-                    {
-                        RenderingManager.RemoveFromPostDrawQueue(3, DrawIcon);
-                    }
-                }
-
-                visible = value;
-            }
-        }
+        public bool Visible { get; set; }
 
         public Icon(Rect defaultPosition, string imageFilename, string noImageText, string tooltip, Action onClickHandler, string configNodeName = "Icon")
         {
@@ -91,6 +65,14 @@ namespace Tac
                 content = new GUIContent(noImageText, tooltip);
             }
         }
+		
+		private void OnGUI()
+		{
+			if (this.Visible)
+			{
+                DrawIcon();
+			}
+		}
 
         private void DrawIcon()
         {

--- a/Source/Window.cs
+++ b/Source/Window.cs
@@ -26,10 +26,8 @@
  */
 
 using KSP.IO;
+using KSP.UI.Dialogs;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace Tac
@@ -77,21 +75,6 @@ namespace Tac
 
         public virtual void SetVisible(bool newValue)
         {
-            if (newValue)
-            {
-                if (!visible)
-                {
-                    RenderingManager.AddToPostDrawQueue(3, new Callback(DrawWindow));
-                }
-            }
-            else
-            {
-                if (visible)
-                {
-                    RenderingManager.RemoveFromPostDrawQueue(3, new Callback(DrawWindow));
-                }
-            }
-
             this.visible = newValue;
         }
 
@@ -199,6 +182,14 @@ namespace Tac
                 resizeStyle.padding = new RectOffset(1, 1, 1, 1);
             }
         }
+		
+		private void OnGUI()
+		{
+			if (visible)
+			{
+				DrawWindow();
+			}
+		}
 
         private void PreDrawWindowContents(int windowId)
         {


### PR DESCRIPTION
Use OnGUI instead of RenderingManager - not sure if this is right fix,
but stops erros/hangs... but not seeing window.
Tested with 1.1, but as noted, the icon does not appear, but TacLifesupport works (no errors as a result of RenderingManager).
